### PR TITLE
change inactivity_timeout from 10(default) to 30 min for slow operation

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -93,7 +93,9 @@ config :mdns_lite,
     }
   ]
 
-config :vintage_net_wizard, captive_portal: false
+config :vintage_net_wizard,
+  captive_portal: false,
+  inactivity_timeout: 30
 
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
I'd like to lengthen the inactivity_timeout, considering that users unfamiliar with the vintage_net_wizard operation.