### PR TITLE
avoid warning in mix.firmware

### DIFF
--- a/lib/sensor/aht20.ex
+++ b/lib/sensor/aht20.ex
@@ -34,9 +34,7 @@ defmodule NervesjpBasis.Sensor.Aht20 do
     IO.puts(" > temp: #{temp()} (degree Celsius)")
   end
 
-  @doc """
-  温度の値を取得
-  """
+  # 温度の値を取得
   defp temp do
     # AHT20から読み出し
     {:ok, {temp, _}} = read_from_aht20()
@@ -55,9 +53,7 @@ defmodule NervesjpBasis.Sensor.Aht20 do
     IO.puts(" > humi: #{humi()} (%)")
   end
 
-  @doc """
-  湿度の値を取得
-  """
+  # 湿度の値を取得
   defp humi do
     # AHT20から読み出し
     {:ok, {_, humi}} = read_from_aht20()
@@ -103,11 +99,9 @@ defmodule NervesjpBasis.Sensor.Aht20 do
     ret
   end
 
-  @doc """
-  生データを温度と湿度の値に変換
-    ## Parameters
-    - val: POSTする内容
-  """
+  #生データを温度と湿度の値に変換
+  ## Parameters
+  ## - val: POSTする内容
   defp convert(src) do
     # バイナリデータ部をバイト分割
     # <<0:state, 1:humi1, 2:humi2, 3:humi3/temp1, 4:temp2, 5:temp3, 6:crc>>

--- a/lib/sensor/web.ex
+++ b/lib/sensor/web.ex
@@ -32,21 +32,17 @@ defmodule NervesjpBasis.Sensor.Web do
     post(temp, @url_temp)
   end
 
-  @doc """
-  指定のURLにPOSTする
-    ## Parameters
-    - val: POSTする内容
-    - url: POSTするAPIのURL
-  """
+  # 指定のURLにPOSTする
+  ## Parameters
+  ## - val: POSTする内容
+  ## - url: POSTするAPIのURL
   defp post(val, url) do
     HTTPoison.post!(url, body(val), header())
   end
 
-  @doc """
-  JSONデータの生成
-    ## Parameters
-    - val: POSTする内容
-  """
+  # JSONデータの生成
+  ## Parameters
+  ## - val: POSTする内容
   defp body(val) do
     # 現在時刻を取得
     time =
@@ -57,9 +53,7 @@ defmodule NervesjpBasis.Sensor.Web do
     Jason.encode!(%{value: %{name: @my_name, value: val, time: time}})
   end
 
-  @doc """
-  ヘッダの生成
-  """
+  # ヘッダの生成
   defp header() do
     [{"Content-type", "application/json"}]
   end

--- a/lib/sensor/webbtn.ex
+++ b/lib/sensor/webbtn.ex
@@ -45,7 +45,7 @@ defmodule NervesjpBasis.Sensor.Webbtn do
   """
   def handle_info({:circuits_gpio, @button, _timestamp, value}, state) do
     # LEDを点灯
-    GPIO.write(state.led, 1)
+    GPIO.write(state.led, value)
     # データを送信
     Web.senddata()
     # 待機（単位ms）


### PR DESCRIPTION
`mix.firmware` の際に出てくる警告（unused variable, doc for defp）が気持ち悪いので除去しました．
前者はちと強引ですが:D
後者は私のワガママのせいですm(_ _)m
https://github.com/NervesJP/nervesjp_basis/pull/7#pullrequestreview-554218875

対応される警告メッセージ：
```
==> nervesjp_basis
Compiling 7 files (.ex)
warning: defp post/2 is private, @doc attribute is always discarded for private functions/macros/types
  lib/sensor/web.ex:35: NervesjpBasis.Sensor.Web.post/2

warning: defp body/1 is private, @doc attribute is always discarded for private functions/macros/types
  lib/sensor/web.ex:45: NervesjpBasis.Sensor.Web.body/1

warning: defp header/0 is private, @doc attribute is always discarded for private functions/macros/types
  lib/sensor/web.ex:60: NervesjpBasis.Sensor.Web.header/0

warning: defp temp/0 is private, @doc attribute is always discarded for private functions/macros/types
  lib/sensor/aht20.ex:37: NervesjpBasis.Sensor.Aht20.temp/0

warning: defp humi/0 is private, @doc attribute is always discarded for private functions/macros/types
  lib/sensor/aht20.ex:58: NervesjpBasis.Sensor.Aht20.humi/0

warning: defp convert/1 is private, @doc attribute is always discarded for private functions/macros/types
  lib/sensor/aht20.ex:106: NervesjpBasis.Sensor.Aht20.convert/1

warning: variable "value" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/sensor/webbtn.ex:46: NervesjpBasis.Sensor.Webbtn.handle_info/2
```

この警告は残りますが，まぁヒントということで+D
```
warning: module attribute @url_humi was set but never used
  lib/sensor/web.ex:16

```